### PR TITLE
Add simple repr for EnsemblDB

### DIFF
--- a/src/genomic_features/ensembl/ensembldb.py
+++ b/src/genomic_features/ensembl/ensembldb.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from functools import cached_property
+
 import ibis
 import requests
 from ibis import _
@@ -113,6 +115,16 @@ class EnsemblDB:
 
     def __init__(self, connection: ibis.BaseBackend):
         self.db = connection
+
+    @cached_property
+    def metadata(self) -> dict:
+        """Metadata for the database (e.g. who built it, when, with what resource)."""
+        metadata_tbl = self.db.table("metadata").execute()
+        return dict(zip(metadata_tbl["name"], metadata_tbl["value"]))
+
+    def __repr__(self) -> str:
+        d = self.metadata
+        return f"EnsemblDB(organism='{d['Organism']}', ensembl_release='{d['ensembl_version']}')"
 
     def genes(
         self, filter: _filters.AbstractFilterExpr = filters.EmptyFilter()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -16,3 +16,10 @@ def test_genes():
 def test_missing_version():
     with pytest.raises(ValueError):
         gf.ensembl.annotation("Hsapiens", 86)
+
+
+def test_repr():
+    result = repr(gf.ensembl.annotation("Hsapiens", 108))
+    expected = "EnsemblDB(organism='Homo sapiens', ensembl_release='108')"
+
+    assert result == expected


### PR DESCRIPTION
```python
import genomic_features as gf

ensdb = gf.ensembl.annotation(species="Hsapiens", version="108")
ensdb
# EnsemblDB(organism='Homo sapiens', ensembl_release='108')
```

Open to changing this up.

This also adds a metadata field for reporting the metadata table:

```python
ensdb.metadata
# {'Db type': 'EnsDb',
#  'Type of Gene ID': 'Ensembl Gene ID',
#  'Supporting package': 'ensembldb',
#  'Db created by': 'ensembldb package from Bioconductor',
#  'script_version': '0.3.7',
#  'Creation time': 'Fri Oct 28 05:24:43 2022',
#  'ensembl_version': '108',
#  'ensembl_host': 'localhost',
#  'Organism': 'Homo sapiens',
#  'taxonomy_id': '9606',
#  'genome_build': 'GRCh38',
#  'DBSCHEMAVERSION': '2.2'}
```