### PR TITLE
Renaming

### DIFF
--- a/docs/notebooks/basic_usage.ipynb
+++ b/docs/notebooks/basic_usage.ipynb
@@ -869,7 +869,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Using the `cols` argument, you can get annotations from other tables in the database."
+    "Using the `columns` argument, you can get annotations from other tables in the database."
    ]
   },
   {
@@ -965,7 +965,7 @@
     }
    ],
    "source": [
-    "ensdb.genes(cols=[\"gene_id\", \"tx_id\", \"gene_name\", \"protein_id\", \"uniprot_id\"]).head()"
+    "ensdb.genes(columns=[\"gene_id\", \"tx_id\", \"gene_name\", \"protein_id\", \"uniprot_id\"]).head()"
    ]
   },
   {

--- a/src/genomic_features/_core/filters.py
+++ b/src/genomic_features/_core/filters.py
@@ -251,7 +251,7 @@ class CanonicalTxFilter(AbstractFilterExpr):
 
     >>> ensdb.transcripts(filter=gf.filters.CanonicalTxFilter())
     >>> ensdb.exons(
-    ...     cols=["tx_id", "exon_id", "seq_name", "exon_seq_start", "exon_seq_end"],
+    ...     columns=["tx_id", "exon_id", "seq_name", "exon_seq_start", "exon_seq_end"],
     ...     filter=gf.filters.CanonicalTxFilter()
     ... )
     """

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -27,7 +27,9 @@ def test_repr():
 
 def test_invalid_join():
     with pytest.raises(ValueError, match=r"Invalid join type: flarb"):
-        gf.ensembl.annotation("Hsapiens", 108).genes(cols=["tx_id"], join_type="flarb")
+        gf.ensembl.annotation("Hsapiens", 108).genes(
+            columns=["tx_id"], join_type="flarb"
+        )
 
 
 def test_exons():

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -60,7 +60,7 @@ def test_required_tables(hsapiens108):
 
 # Test simple subsetting to columns in one table gene
 def test_simple_subsetting(hsapiens108):
-    result = hsapiens108.genes(cols=["gene_id", "gene_name"])
+    result = hsapiens108.genes(columns=["gene_id", "gene_name"])
     assert result.shape == (70616, 2)
     assert result.columns.tolist() == ["gene_id", "gene_name"]
 
@@ -69,7 +69,7 @@ def test_simple_subsetting(hsapiens108):
 def test_multiple_table_subsetting(hsapiens108):
     # table genes and transcripts
     result = hsapiens108.genes(
-        cols=["gene_id", "gene_name", "tx_id"],
+        columns=["gene_id", "gene_name", "tx_id"],
         join_type="inner",
     )
     assert result.shape == (275721, 3)
@@ -77,7 +77,7 @@ def test_multiple_table_subsetting(hsapiens108):
 
     # table genes and transcripts with filter
     result = hsapiens108.genes(
-        cols=["gene_id", "gene_name", "tx_id"],
+        columns=["gene_id", "gene_name", "tx_id"],
         join_type="inner",
         filter=gf.filters.GeneBioTypeFilter(["protein_coding"]),
     )
@@ -86,7 +86,7 @@ def test_multiple_table_subsetting(hsapiens108):
 
     # table genes, transcripts and exons and filter
     result = hsapiens108.genes(
-        cols=["gene_id", "gene_name", "exon_id"],
+        columns=["gene_id", "gene_name", "exon_id"],
         join_type="inner",
         filter=gf.filters.GeneIDFilter(["ENSG00000139618"]),
     )
@@ -97,7 +97,7 @@ def test_multiple_table_subsetting(hsapiens108):
     # test left join
     # table genes and transcripts
     result = hsapiens108.genes(
-        cols=["gene_id", "gene_name", "protein_id"],
+        columns=["gene_id", "gene_name", "protein_id"],
         join_type="left",
         filter=gf.filters.GeneBioTypeFilter(["protein_coding"]),
     )
@@ -115,7 +115,7 @@ def test_multiple_table_subsetting(hsapiens108):
 
 def test_chromosome_columns(hsapiens108):
     # https://github.com/scverse/genomic-features/pull/44/files#r1196331705
-    result = hsapiens108.genes(cols=["gene_id", "seq_name", "seq_length"])
+    result = hsapiens108.genes(columns=["gene_id", "seq_name", "seq_length"])
     assert result.shape[0] == hsapiens108.db.table("gene").count().execute()
 
     chroms = hsapiens108.chromosomes()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -77,7 +77,7 @@ def test_equality_filter_list(hsapiens108, filt, table_method):
 def test_canonical(hsapiens108, table_method):
     func = table_method(hsapiens108)
     result = func(
-        cols=["tx_id", "canonical_transcript"], filter=filters.CanonicalTxFilter()
+        columns=["tx_id", "canonical_transcript"], filter=filters.CanonicalTxFilter()
     )
 
     assert result["tx_is_canonical"].sum() == result.shape[0]
@@ -86,7 +86,7 @@ def test_canonical(hsapiens108, table_method):
     )
 
     result_non_canonical = func(
-        cols=["tx_id", "canonical_transcript"], filter=~filters.CanonicalTxFilter()
+        columns=["tx_id", "canonical_transcript"], filter=~filters.CanonicalTxFilter()
     )
 
     assert result_non_canonical["tx_is_canonical"].sum() == 0


### PR DESCRIPTION
Closes #47 


- [ ] `GeneRangesFilter` -> `GeneRangeFilter` (since it only takes a single range)
- [ ] `CanonicalFilter` -> ???
- [x] `genes(cols=...)` -> `genes(columns=...)` – Just to be more consistent. Could go the other way and use `cols` everywhere.
- [ ] What are the canonical strand names? `+`, `-` I assume?