### PR TITLE
Fix: Add tqdm dependency and remove prettier from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,16 +14,6 @@ repos:
       rev: 1.13.0
       hooks:
           - id: blacken-docs
-    - repo: https://github.com/pre-commit/mirrors-prettier
-      rev: v3.0.0-alpha.9-for-vscode
-      hooks:
-          - id: prettier
-            # Newer versions of node don't work on systems that have an older version of GLIBC
-            # (in particular Ubuntu 18.04 and Centos 7)
-            # EOL of Centos 7 is in 2024-06, we can probably get rid of this then.
-            # See https://github.com/scverse/cookiecutter-scverse/issues/143 and
-            # https://github.com/jupyterlab/jupyterlab/issues/12675
-            language_version: "17.9.1"
     - repo: https://github.com/charliermarsh/ruff-pre-commit
       rev: v0.0.262
       hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ dependencies = [
     "pandas",
     "pyarrow",
     # for debug logging (referenced from the issue template)
-    "session-info"
+    "session-info",
+    "tqdm"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR:
- Adds `tqdm` which is a required dependency
- Removes `prettier` from pre-commit, which I can't install on my system and is probably not required.