### PR TITLE
Feat: Use duckdb as backend instead of sqlite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ urls.Documentation = "https://genomic-features.readthedocs.io/"
 urls.Source = "https://github.com/scverse/genomic-features"
 urls.Home-page = "https://github.com/scverse/genomic-features"
 dependencies = [
-    "ibis-framework[sqlite]>0.6",
+    "ibis-framework[sqlite, duckdb]>0.6",
     "pooch",
     "pandas",
     "pyarrow",

--- a/src/genomic_features/ensembl/ensembldb.py
+++ b/src/genomic_features/ensembl/ensembldb.py
@@ -32,7 +32,7 @@ TIMESTAMP_URL = "https://annotationhub.bioconductor.org/metadata/database_timest
 
 
 def annotation(
-    species: str, version: str | int, backend: Literal["duckdb", "sqlite"] = "duckdb"
+    species: str, version: str | int, backend: Literal["duckdb", "sqlite"] = "sqlite"
 ) -> EnsemblDB:
     """Get an annotation database for a species and version.
 

--- a/src/genomic_features/ensembl/ensembldb.py
+++ b/src/genomic_features/ensembl/ensembldb.py
@@ -32,7 +32,7 @@ TIMESTAMP_URL = "https://annotationhub.bioconductor.org/metadata/database_timest
 
 
 def annotation(
-    species: str, version: str | int, backend: Literal["duckdb", "sqlite"] = "sqlite"
+    species: str, version: str | int, backend: Literal["duckdb", "sqlite"] = "duckdb"
 ) -> EnsemblDB:
     """Get an annotation database for a species and version.
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -197,11 +197,20 @@ def test_negation(hsapiens108):
 def test_seqs_as_int(hsapiens108):
     result_w_int = hsapiens108.genes(filter=filters.SeqNameFilter(1))
     result_w_str = hsapiens108.genes(filter=filters.SeqNameFilter("1"))
-    pd.testing.assert_frame_equal(result_w_int, result_w_str)
+    pd.testing.assert_frame_equal(
+        result_w_int.sort_values(by="gene_id").reset_index(drop=True),
+        result_w_str.sort_values(by="gene_id").reset_index(drop=True),
+    )
 
     result_w_ints = hsapiens108.genes(filter=filters.SeqNameFilter([1, 2]))
     result_w_strs = hsapiens108.genes(filter=filters.SeqNameFilter(["1", "2"]))
     result_w_mixed = hsapiens108.genes(filter=filters.SeqNameFilter([1, "2"]))
 
-    pd.testing.assert_frame_equal(result_w_ints, result_w_strs)
-    pd.testing.assert_frame_equal(result_w_ints, result_w_mixed)
+    pd.testing.assert_frame_equal(
+        result_w_ints.sort_values(by="gene_id").reset_index(drop=True),
+        result_w_strs.sort_values(by="gene_id").reset_index(drop=True),
+    )
+    pd.testing.assert_frame_equal(
+        result_w_ints.sort_values(by="gene_id").reset_index(drop=True),
+        result_w_mixed.sort_values(by="gene_id").reset_index(drop=True),
+    )

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -194,12 +194,15 @@ def test_negation(hsapiens108):
     assert result.shape[0] == 22894
 
 
-def test_seqs_as_int(hsapiens108):
+@pytest.mark.parametrize("backend", ["sqlite", "duckdb"])
+def test_seqs_as_int(backend):
+    hsapiens108 = gf.ensembl.annotation("Hsapiens", 108, backend=backend)
+
     result_w_int = hsapiens108.genes(filter=filters.SeqNameFilter(1))
     result_w_str = hsapiens108.genes(filter=filters.SeqNameFilter("1"))
     pd.testing.assert_frame_equal(
-        result_w_int.sort_values(by="gene_id").reset_index(drop=True),
-        result_w_str.sort_values(by="gene_id").reset_index(drop=True),
+        result_w_int,
+        result_w_str,
     )
 
     result_w_ints = hsapiens108.genes(filter=filters.SeqNameFilter([1, 2]))
@@ -207,10 +210,10 @@ def test_seqs_as_int(hsapiens108):
     result_w_mixed = hsapiens108.genes(filter=filters.SeqNameFilter([1, "2"]))
 
     pd.testing.assert_frame_equal(
-        result_w_ints.sort_values(by="gene_id").reset_index(drop=True),
-        result_w_strs.sort_values(by="gene_id").reset_index(drop=True),
+        result_w_ints,
+        result_w_strs,
     )
     pd.testing.assert_frame_equal(
-        result_w_ints.sort_values(by="gene_id").reset_index(drop=True),
-        result_w_mixed.sort_values(by="gene_id").reset_index(drop=True),
+        result_w_ints,
+        result_w_mixed,
     )


### PR DESCRIPTION
This PR adds a `backend` (default: sqlite, optional: duckdb). Also it forces ordering by columns requested in order. 

Benchmarking:
---------------
Running tests using DuckDB backend
pytest  40.40s user 7.76s system 196% cpu 24.544 total
Running tests using Sqlite3
pytest  39.02s user 10.77s system 97% cpu 51.043 total

DuckDB is twice as fast because it used two cores, but about the same number of cpu cycles.