### PR TITLE
Sort output

### DIFF
--- a/src/genomic_features/ensembl/ensembldb.py
+++ b/src/genomic_features/ensembl/ensembldb.py
@@ -163,7 +163,12 @@ class EnsemblDB:
         cols: list[str] | None = None,
         filter: AbstractFilterExpr = filters.EmptyFilter(),
         join_type: Literal["inner", "left"] = "inner",
-        order_by: Sequence[str] | str = ("seq_name", "gene_seq_start", "gene_seq_end"),
+        order_by: Sequence[str] | str = (
+            "seq_name",
+            "gene_seq_start",
+            "gene_seq_end",
+            "gene_id",
+        ),
     ) -> DataFrame:
         """Get gene annotations.
 
@@ -249,12 +254,7 @@ class EnsemblDB:
         cols: list[str] | None = None,
         filter: AbstractFilterExpr = filters.EmptyFilter(),
         join_type: Literal["inner", "left"] = "inner",
-        order_by: Sequence[str] | str = (
-            "seq_name",
-            "exon_seq_start",
-            "exon_seq_end",
-            "exon_id",
-        ),
+        order_by: Sequence[str] | str = ("exon_id"),
     ) -> DataFrame:
         """Get exons table.
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -90,3 +90,23 @@ def test_join_sort_ordering(backend):
         ["seq_name", "gene_seq_start", "exon_seq_start", "exon_id", "gene_id"]
     ).reset_index(drop=True)
     pd.testing.assert_frame_equal(df, df_resorted)
+
+
+@pytest.mark.parametrize("backend", ["sqlite", "duckdb"])
+def test_custom_ordering(backend):
+    ensdb = gf.ensembl.annotation("Hsapiens", ENSEMBL_RELEASE, backend=backend)
+    df = ensdb.genes(
+        [
+            "seq_name",
+            "gene_seq_start",
+            "gene_seq_end",
+            "exon_id",
+            "exon_seq_start",
+            "exon_seq_end",
+        ],
+        order_by="exon_id",
+    )
+
+    # Test sort order
+    df_resorted = df.sort_values(["exon_id"]).reset_index(drop=True)
+    pd.testing.assert_frame_equal(df, df_resorted)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -27,6 +27,11 @@ def test_missing_version():
         gf.ensembl.annotation("Hsapiens", 86)
 
 
+def test_invalid_backend():
+    with pytest.raises(ValueError):
+        gf.ensembl.annotation("Hsapiens", ENSEMBL_RELEASE, backend="bad_idea")
+
+
 def test_repr():
     result = repr(gf.ensembl.annotation("Hsapiens", ENSEMBL_RELEASE))
     expected = (

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -8,8 +8,9 @@ def test_package_has_version():
     assert gf.__version__ is not None
 
 
-def test_genes():
-    genes = gf.ensembl.annotation("Hsapiens", 108).genes()
+@pytest.mark.parametrize("backend", ["sqlite", "duckdb"])
+def test_genes(backend):
+    genes = gf.ensembl.annotation("Hsapiens", 108, backend=backend).genes()
     assert isinstance(genes, pd.DataFrame)
 
 
@@ -30,8 +31,9 @@ def test_invalid_join():
         gf.ensembl.annotation("Hsapiens", 108).genes(cols=["tx_id"], join_type="flarb")
 
 
-def test_exons():
-    ensdb = gf.ensembl.annotation("Hsapiens", 108)
+@pytest.mark.parametrize("backend", ["sqlite", "duckdb"])
+def test_exons(backend):
+    ensdb = gf.ensembl.annotation("Hsapiens", 108, backend=backend)
     exons = ensdb.exons()
 
     pd.testing.assert_index_equal(

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -13,6 +13,12 @@ def test_genes(backend):
     genes = gf.ensembl.annotation("Hsapiens", 108, backend=backend).genes()
     assert isinstance(genes, pd.DataFrame)
 
+    # Test sort order
+    genes_resorted = genes.sort_values(
+        ["seq_name", "gene_seq_start", "gene_id"]
+    ).reset_index(drop=True)
+    pd.testing.assert_frame_equal(genes, genes_resorted)
+
 
 def test_missing_version():
     with pytest.raises(ValueError):
@@ -46,3 +52,9 @@ def test_exons(backend):
 
     pd.testing.assert_index_equal(exons_id.columns, pd.Index(["exon_id"]))
     assert exons_id.shape[0] == exons.shape[0]
+
+    # Test sort order
+    exons_resorted = exons.sort_values(
+        ["seq_name", "exon_seq_start", "exon_id"]
+    ).reset_index(drop=True)
+    pd.testing.assert_frame_equal(exons, exons_resorted)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -194,10 +194,7 @@ def test_negation(hsapiens108):
     assert result.shape[0] == 22894
 
 
-@pytest.mark.parametrize("backend", ["sqlite", "duckdb"])
-def test_seqs_as_int(backend):
-    hsapiens108 = gf.ensembl.annotation("Hsapiens", 108, backend=backend)
-
+def test_seqs_as_int(hsapiens108):
     result_w_int = hsapiens108.genes(filter=filters.SeqNameFilter(1))
     result_w_str = hsapiens108.genes(filter=filters.SeqNameFilter("1"))
     pd.testing.assert_frame_equal(


### PR DESCRIPTION
This PR orders the results. By default, it's ordered by chrom, start, and id. Custom ordering can be provided using `order_by`. 

If subsets of columns are selected, then the columns are sorted with available columns and finally by `id`.